### PR TITLE
Ŝanĝis GET /?list=N al GET /?tranĉi=N,M

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .gradle/
 build/
 .idea/
+keystore.jks

--- a/README.md
+++ b/README.md
@@ -14,44 +14,69 @@ Por kurigi la apon, oni devas fari la jenajn paŝojn:
    a. La havenoj, kiuj konektebliĝas, estas 5000 (HTTP) kaj 8443 (HTTPS) se ĉio estas en ordo
 5. Konekti al la HTTP aŭ HTTPS havenoj por testi ilin
     Rem: Kiam vi konektas al HTTPS, via retumilo eble diras al vi, ke la retejo estas malsekura. Ĉio, kion vi devas fari estas:
-        1. Alklaki "Altnivela" aŭ "Advanced" angle
-        2. Alklaki "Procedi..."
+        1. Alklaki "Spertula" aŭ "Advanced" angle
+        2. Alklaki "Akcepti la riskon kaj daŭrigi..."
 
 ## Dokumentaĵo de la kodo
 TODO: Skribi la dokumentaĵojn de la kodo
 
 ## API
 
-### GET /?listo=N
-Tiu ĉi peto estas uzata por havigi la tutan vortaron *N* vortoj samtempe, kie *N* estas la nombro da vortoj por havigi.
+### GET /?tranĉi=N,M
+Tiu ĉi peto estas uzata por havigi la tutan vortaron, tranĉite de *N* ĝis *M* indeksoj, 
+kie *N* estas la indekso de la komenco de la listo, kaj *M* estas la indekso de la fino de la listo.
 
 Peto:
 ```
 HTTP/1.1 localhost:5000
-GET /?listo=10
+GET /?tranĉi=0,10
 ```
 
 Respondo:
 ```
 HTTP/1.1 localhost:5000
-GET /?listo=10
+GET /?tranĉi=0,10
 BODY
 [
     {
-        "word": "dormi",
-        "definition": "Esti en tiu stato de korpa k intelekta senaktiveco, kiu ordinare okazas ĉiunokte k estas necesa por ripozigi la homojn k la bestojn"
+        "word": "akvo",
+        "definition": "Likva kombinaĵo de hidrogeno k oksigeno, H2O"
     },
     {
-        "word": "dormo",
-        "definition": "Stato de dormanto"
+        "word": "besto",
+        "definition": "Ĉiu animalo escepte de homo: hejma, sovaĝa besto"
+    },
+    {
+        "word": "diri",
+        "definition": "Voĉe komuniki sencohavajn vortojn"
     },
     {
         "word": "enmeti",
         "definition": "Meti en"
     },
     {
-        "word": "saluto",
-        "definition": "Ekstera signo de ĝentileco, kiun oni esprimas per vortoj aŭ movoj al renkontata persono"
+        "word": "homo",
+        "definition": "de mamuloj, karakterizata de vertikala teniĝo, forte evoluinta cerbo k parolkapablo"
+    },
+    {
+        "word": "iri",
+        "definition": "Moviĝi per la tiucelaj membroj, piedoj, flugiloj, naĝiloj"
+    },
+    {
+        "word": "komputilo",
+        "definition": "Aparato, kiu aŭtomate prilaboras datenojn laŭ instrukcioj"
+    },
+    {
+        "word": "lando",
+        "definition": "Parto de la tersurfaco, rigardata kiel geografia apartaĵo"
+    },
+    {
+        "word": "ludi",
+        "definition": "Vigle, libere, kaprice, sencele sin movi tien k reen en vivoĝojo"
+    },
+    {
+        "word": "mano",
+        "definition": "Ekstrema, artikigita parto de la brako de homo aŭ de simio, havanta kvin fingrojn, el kiuj unu estas kontraŭmetebla al la ceteraj"
     }
 ]
 ```

--- a/src/commonMain/kotlin/User.kt
+++ b/src/commonMain/kotlin/User.kt
@@ -1,5 +1,5 @@
 @kotlinx.serialization.Serializable
 data class User(
     val username: String,
-    val passwordHashed: String
+    val password: String
 )

--- a/src/jsMain/kotlin/vidoj/Vortlisto.kt
+++ b/src/jsMain/kotlin/vidoj/Vortlisto.kt
@@ -15,6 +15,7 @@ import react.dom.html.ReactHTML.ul
 external interface WordListProps: Props {
     var words: List<WordEntry>
     var onWordClick: (WordEntry) -> Unit
+    var onScroll: ()->Unit
 }
 
 val WordList = FC<WordListProps>{ props ->
@@ -24,9 +25,17 @@ val WordList = FC<WordListProps>{ props ->
             width = 50.pct
             height = 100.pct - 3.em
             marginTop = 3.em
+            overflow = Overflow.scroll
 //            marginRight = 5.pct
         }
         if(props.words.isNotEmpty()) {
+            onScroll = {
+                it.currentTarget.let{ target ->
+                    if(target.scrollHeight - target.scrollTop == target.clientHeight.toDouble()){
+                        props.onScroll()
+                    }
+                }
+            }
             ul {
                 props.words.forEach { word ->
                     li {

--- a/src/jvmMain/kotlin/net/miavortaro/application/Server.kt
+++ b/src/jvmMain/kotlin/net/miavortaro/application/Server.kt
@@ -21,13 +21,13 @@ import io.ktor.server.plugins.conditionalheaders.*
 import io.ktor.server.plugins.contentnegotiation.*
 import io.ktor.server.plugins.defaultheaders.*
 import io.ktor.server.plugins.partialcontent.*
-import io.ktor.server.request.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
 import io.ktor.server.sessions.*
 import io.ktor.util.*
 import net.miavortaro.application.itineroj.admin
 import net.miavortaro.application.itineroj.ensaluti
+import net.miavortaro.application.itineroj.index
 import net.miavortaro.application.itineroj.registry
 import org.jetbrains.exposed.sql.Database
 import java.io.File
@@ -67,7 +67,7 @@ fun createToken(audience: String, issuer: String, user: User, secret: String): S
         .withAudience(audience)
         .withIssuer(issuer)
         .withClaim("username", user.username)
-        .withClaim("hashedPassword", user.passwordHashed)
+        .withClaim("hashedPassword", user.password)
         .withExpiresAt(Date(System.currentTimeMillis() + (30 * 60 * 1000)))
         .sign(Algorithm.HMAC256(secret))
 
@@ -129,6 +129,8 @@ fun Application.mainWithDependencies(dao: DAOFacade){
             }
         }
     }
+
+    dao.createUser(User("Admin", "zamenhof7881"))
 
     routing{
         index()


### PR DESCRIPTION
## La Ŝanĝoj
GET /?list=N ne sufiĉis por la listo funkcii ĝuste. Ne estis maniero antaŭe por ŝargi la jenajn vortojn en la listo de la servilo, do la servilon devis ŝanĝi mi, kiel jene:

1. La servilo datumbazo nun havas "tranĉi" demandon
2. La kliento nun povas rulumi kaj daŭre ŝargi de la servilo la jenajn vortojn en la nuna listo

## La Jenaj Paŝoj
1. Ĝisdatigu la Python-an libraron por subteni ĉi tiujn ŝanĝojn
2. Permesu ke la adminoj povas ensaluti universale
3. Skribu la unuan testilon por testi la servilon
4. Integri novajn konstruajn instrukciojn por certigi ke la servilo ĉiam plenigas sendepende de la gastiga komputilo, Gita branĉo, ktp 